### PR TITLE
Update README links to current docs and pricing URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ option within the Project – References node.
 
 ### Getting Paubox API Credentials
 
-You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/join/see-pricing?unit=messages).
+You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/pricing/paubox-email-api).
 
 Once you have an account, follow the instructions on the Rest API dashboard to verify domain ownership and generate API
 credentials.
@@ -153,7 +153,7 @@ var paubox = new EmailLibrary(configuration);
 
 ### Send Message
 
-Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/messages#send-message).
+Please also see the [API Documentation](https://docs.paubox.com/email-api/messages).
 
 To send an email, prepare a `Message` object with `Header` and `Content` and call `EmailLibrary.SendMessage`:
 
@@ -264,7 +264,7 @@ SendMessageResponse response = paubox.SendMessage(message);
 
 #### Custom Headers
 
-Please see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/messages#data-parameters) for more
+Please see the [API Documentation](https://docs.paubox.com/email-api/messages) for more
 information on custom headers. You can add custom headers to your message by adding them as a Dictionary to the `Header`
 object:
 
@@ -288,7 +288,7 @@ SendMessageResponse response = paubox.SendMessage(message);
 
 ### Get Email Disposition
 
-Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/messages#get-email-disposition).
+Please also see the [API Documentation](https://docs.paubox.com/email-api/message-receipt).
 
 To get email status for any source tracking id, call the `EmailLibrary.GetEmailDisposition` method with the source
 tracking id of the message:
@@ -299,7 +299,7 @@ GetEmailDispositionResponse response = paubox.GetEmailDisposition("2a3c048485aa4
 
 ### Send Bulk Messages
 
-Please see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/messages#send-bulk-messages) for more
+Please see the [API Documentation](https://docs.paubox.com/email-api/bulk-messages) for more
 details. Specifically:
 
 > We recommend batches of 50 (fifty) or less.
@@ -322,7 +322,7 @@ SendBulkMessagesResponse response = paubox.SendBulkMessages(messages);
 
 ### Dynamic Templates
 
-Please refer to the [related API documentation](https://docs.paubox.com/docs/paubox_email_api/dynamic_templates) for
+Please refer to the [related API documentation](https://docs.paubox.com/email-api/dynamic-templates) for
 more details.
 
 #### Create Dynamic Template
@@ -401,7 +401,7 @@ List<DynamicTemplateSummary> result = paubox.ListDynamicTemplates();
 
 #### Send a Dynamically Templated Message
 
-To [send a dynamically templated message](https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message),
+To [send a dynamically templated message](https://docs.paubox.com/email-api/templated-messages),
 firstly construct a new `TemplatedMessage` object:
 
 ```csharp


### PR DESCRIPTION
## Summary

- The Paubox docs site moved from the legacy Swagger-style layout (`docs.paubox.com/docs/paubox_email_api/...#anchor`) to Mintlify (`docs.paubox.com/email-api/...`), and the marketing pricing page moved from `/join/see-pricing` to `/pricing/paubox-email-api`. Readers following the old `README.md` links currently hit redirects or 404s.
- Rewrites 7 links in `README.md` to their current canonical targets per the established mapping. No code, tests, or `api.paubox.net/v1/...` endpoints are touched.

## Mapping applied

| Section | Old | New |
|---|---|---|
| Getting Paubox API Credentials | `www.paubox.com/join/see-pricing?unit=messages` | `www.paubox.com/pricing/paubox-email-api` |
| Send Message | `.../messages#send-message` | `/email-api/messages` |
| Custom Headers | `.../messages#data-parameters` | `/email-api/messages` |
| Get Email Disposition | `.../messages#get-email-disposition` | `/email-api/message-receipt` |
| Send Bulk Messages | `.../messages#send-bulk-messages` | `/email-api/bulk-messages` |
| Dynamic Templates | `.../dynamic_templates` | `/email-api/dynamic-templates` |
| Send a Dynamically Templated Message | `.../dynamic_templates#send-a-dynamically-templated-message` | `/email-api/templated-messages` |

## Test plan

- [ ] `git diff --stat` shows only `README.md` (7 insertions / 7 deletions)
- [ ] `grep -rn 'paubox_email_api\|join/see-pricing' .` returns zero matches
- [ ] Render the README on the PR page and click each of the 7 links to confirm 200 OK
- [ ] Spot-check link text in each section is unchanged (only URLs differ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)