### PR TITLE
Add Paubox Forms API support with FormsLibrary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md — Paubox C# SDK
+
+This file provides context for AI-assisted development on this repository.
+
+## Project Overview
+
+This is the official Paubox C# SDK. It wraps two Paubox APIs:
+
+| Library | Class | Base URL | Auth |
+|---|---|---|---|
+| Email API | `EmailLibrary` | `https://api.paubox.net/v1/{apiUser}/` | `Token token={apiKey}` header |
+| Forms API | `FormsLibrary` | `https://next.paubox.com/` | None (public endpoints) |
+
+## Repository Structure
+
+```
+paubox-csharp/
+├── README.md                  # User-facing setup and usage guide
+├── api.md                     # API reference for both libraries
+├── CLAUDE.md                  # This file
+├── lib/                       # Pre-compiled DLL (Paubox.Email.API.dll)
+└── Paubox_Csharp/
+    ├── Paubox_Csharp.sln
+    ├── EmailLib/              # Core library project
+    │   ├── APIHelper.cs       # HTTP layer (HttpClient wrapper)
+    │   ├── IAPIHelper.cs      # Interface for APIHelper (injectable for tests)
+    │   ├── EmailLibrary.cs    # Email API client
+    │   ├── IEmailLibrary.cs   # Email API interface
+    │   ├── FormsLibrary.cs    # Forms API client
+    │   ├── IFormsLibrary.cs   # Forms API interface
+    │   ├── CommonClasses.cs   # Email-related models and response types
+    │   ├── FormsClasses.cs    # Forms-related models (Form, FormAttachment)
+    │   ├── Message.cs         # Email message model
+    │   ├── BaseMessage.cs     # Abstract base for email messages
+    │   └── TemplatedMessage.cs
+    └── UnitTestProject/       # NUnit test suite
+        ├── GetFormTest.cs
+        ├── SubmitFormTest.cs
+        ├── SendMessageTest.cs
+        └── ... (other test files)
+```
+
+## Running Tests
+
+```bash
+dotnet test Paubox_Csharp/UnitTestProject/UnitTestProject.csproj
+```
+
+Build only:
+
+```bash
+dotnet build Paubox_Csharp/Paubox_Csharp.sln
+```
+
+Target framework: **.NET 8.0**
+
+## Key Patterns
+
+### HTTP Layer
+
+`APIHelper` wraps `HttpClient` and is injected via `IAPIHelper`. All library constructors accept
+an `IAPIHelper` parameter for testing:
+
+```csharp
+var lib = new FormsLibrary(_mockApiHelper.Object);   // tests
+var lib = new FormsLibrary();                         // production
+```
+
+`CallToAPI` signature:
+```csharp
+string CallToAPI(string baseUrl, string requestUri, string authHeader, string apiVerb, string requestBody = "")
+```
+
+Passing `null` for `authHeader` is safe — the header is only added when non-null and non-empty.
+
+### JSON Serialization
+
+All JSON handling uses **Newtonsoft.Json**. Response models use `[JsonProperty("snake_case_name")]`
+attributes to map API field names to PascalCase C# properties.
+
+### Error Handling
+
+Both libraries throw `SystemException` with the raw API response body as the message when the API
+returns an error. Guard conditions throw `ArgumentException` / `ArgumentNullException` for invalid
+inputs before making any HTTP call.
+
+### Test Structure
+
+Each public method has a corresponding `*Test.cs` file in `UnitTestProject/`. Tests use:
+- **NUnit 3** as the test framework
+- **Moq** to mock `IAPIHelper`
+- Moq `.Callback<>()` to capture request arguments for payload verification
+
+## Development Branch
+
+Active feature work: `claude/paubox-forms-api-support-hAB2b`
+
+## Adding New Endpoints
+
+1. Add model classes to `CommonClasses.cs` (Email API) or `FormsClasses.cs` (Forms API)
+2. Add the method signature to the relevant interface (`IEmailLibrary` or `IFormsLibrary`)
+3. Implement in `EmailLibrary.cs` or `FormsLibrary.cs`
+4. Add a `*Test.cs` file in `UnitTestProject/` covering happy path, error cases, and payload shape
+5. Update `README.md` and `api.md`

--- a/Paubox_Csharp/EmailLib/FormsClasses.cs
+++ b/Paubox_Csharp/EmailLib/FormsClasses.cs
@@ -1,0 +1,71 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Paubox
+{
+    public class Form
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("form_html")]
+        public string FormHtml { get; set; }
+
+        [JsonProperty("form_json")]
+        public object FormJson { get; set; }
+
+        [JsonProperty("form_css")]
+        public string FormCss { get; set; }
+
+        [JsonProperty("vanity_url")]
+        public string VanityUrl { get; set; }
+
+        [JsonProperty("version")]
+        public int Version { get; set; }
+
+        [JsonProperty("active")]
+        public bool Active { get; set; }
+
+        [JsonProperty("customer_id")]
+        public int CustomerId { get; set; }
+
+        [JsonProperty("signable")]
+        public bool Signable { get; set; }
+
+        [JsonProperty("signature_confirmation_label")]
+        public string SignatureConfirmationLabel { get; set; }
+
+        [JsonProperty("submission_count")]
+        public int SubmissionCount { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("deleted")]
+        public bool Deleted { get; set; }
+
+        [JsonProperty("archived")]
+        public bool Archived { get; set; }
+
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [JsonProperty("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+    }
+
+    public class FormAttachment
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("content")]
+        public string Content { get; set; }
+    }
+}

--- a/Paubox_Csharp/EmailLib/FormsLibrary.cs
+++ b/Paubox_Csharp/EmailLib/FormsLibrary.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Paubox
+{
+    public class FormsLibrary : IFormsLibrary
+    {
+        private const string FormsBaseUrl = "https://next.paubox.com/";
+        private readonly IAPIHelper _apiHelper;
+
+        public FormsLibrary() : this(new APIHelper())
+        {
+        }
+
+        public FormsLibrary(IAPIHelper apiHelper)
+        {
+            _apiHelper = apiHelper ?? throw new ArgumentNullException(nameof(apiHelper));
+        }
+
+        public Form GetForm(string formId)
+        {
+            if (string.IsNullOrWhiteSpace(formId))
+                throw new ArgumentException("Form ID cannot be null or empty", nameof(formId));
+
+            string response = _apiHelper.CallToAPI(FormsBaseUrl,
+                $"public/form_data/{formId}", null, "GET");
+
+            Form form = JsonConvert.DeserializeObject<Form>(response);
+            if (form == null || form.Id == null)
+                throw new SystemException(response);
+
+            return form;
+        }
+
+        public void SubmitForm(string formId, Dictionary<string, object> formData,
+                               FormAttachment[] attachments = null)
+        {
+            if (string.IsNullOrWhiteSpace(formId))
+                throw new ArgumentException("Form ID cannot be null or empty", nameof(formId));
+            if (formData == null)
+                throw new ArgumentNullException(nameof(formData));
+
+            var body = new Dictionary<string, object> { ["form_data"] = formData };
+            if (attachments != null && attachments.Length > 0)
+                body["attachments"] = attachments;
+
+            string response = _apiHelper.CallToAPI(FormsBaseUrl,
+                $"api/forms/{formId}/submissions", null, "POST",
+                JsonConvert.SerializeObject(body));
+
+            if (!string.IsNullOrWhiteSpace(response))
+                throw new SystemException(response);
+        }
+    }
+}

--- a/Paubox_Csharp/EmailLib/IFormsLibrary.cs
+++ b/Paubox_Csharp/EmailLib/IFormsLibrary.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Paubox
+{
+    public interface IFormsLibrary
+    {
+        Form GetForm(string formId);
+        void SubmitForm(string formId, Dictionary<string, object> formData, FormAttachment[] attachments = null);
+    }
+}

--- a/Paubox_Csharp/UnitTestProject/GetFormTest.cs
+++ b/Paubox_Csharp/UnitTestProject/GetFormTest.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Moq;
+using Paubox;
+using Newtonsoft.Json;
+
+[TestFixture]
+public class GetFormTest
+{
+    private Mock<IAPIHelper> _mockApiHelper;
+    private FormsLibrary _formsLibrary;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockApiHelper = new Mock<IAPIHelper>();
+        _formsLibrary = new FormsLibrary(_mockApiHelper.Object);
+    }
+
+    [Test]
+    public void TestGetFormHappyCaseReturnsFormFields()
+    {
+        string apiResponse = SuccessResponse();
+        MockApiResponse(apiResponse);
+
+        Form result = _formsLibrary.GetForm("550e8400-e29b-41d4-a716-446655440000");
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("550e8400-e29b-41d4-a716-446655440000", result.Id);
+        Assert.AreEqual("Patient Intake Form", result.Title);
+        Assert.AreEqual("Please complete before your appointment.", result.Description);
+        Assert.AreEqual("<form>...</form>", result.FormHtml);
+        Assert.AreEqual("form { font-family: sans-serif; }", result.FormCss);
+        Assert.IsTrue(result.Active);
+        Assert.AreEqual(123, result.CustomerId);
+        Assert.IsFalse(result.Signable);
+        Assert.AreEqual(42, result.SubmissionCount);
+    }
+
+    [Test]
+    public void TestGetFormNotFoundThrowsSystemException()
+    {
+        MockApiResponse(NotFoundResponse());
+
+        var exception = Assert.Throws<SystemException>(
+            () => _formsLibrary.GetForm("550e8400-e29b-41d4-a716-446655440000"));
+
+        Assert.IsNotNull(exception.Message);
+    }
+
+    [Test]
+    public void TestGetFormEmptyResponseThrowsSystemException()
+    {
+        MockApiResponse("{}");
+
+        Assert.Throws<SystemException>(
+            () => _formsLibrary.GetForm("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    [Test]
+    public void TestGetFormNullFormIdThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => _formsLibrary.GetForm(null));
+    }
+
+    [Test]
+    public void TestGetFormEmptyFormIdThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => _formsLibrary.GetForm(""));
+    }
+
+    [Test]
+    public void TestGetFormCallsCorrectUrl()
+    {
+        string capturedBaseUrl = null;
+        string capturedRequestUri = null;
+
+        _mockApiHelper
+            .Setup(x => x.CallToAPI(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()))
+            .Callback<string, string, string, string, string>(
+                (baseUrl, uri, auth, verb, body) =>
+                {
+                    capturedBaseUrl = baseUrl;
+                    capturedRequestUri = uri;
+                })
+            .Returns(SuccessResponse());
+
+        _formsLibrary.GetForm("550e8400-e29b-41d4-a716-446655440000");
+
+        Assert.AreEqual("https://next.paubox.com/", capturedBaseUrl);
+        Assert.AreEqual("public/form_data/550e8400-e29b-41d4-a716-446655440000", capturedRequestUri);
+    }
+
+    [Test]
+    public void TestGetFormPassesNoAuthorizationHeader()
+    {
+        string capturedAuth = "sentinel";
+
+        _mockApiHelper
+            .Setup(x => x.CallToAPI(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()))
+            .Callback<string, string, string, string, string>(
+                (baseUrl, uri, auth, verb, body) => { capturedAuth = auth; })
+            .Returns(SuccessResponse());
+
+        _formsLibrary.GetForm("550e8400-e29b-41d4-a716-446655440000");
+
+        Assert.IsNull(capturedAuth);
+    }
+
+    // ------------------------------------------------------------
+    // Helper methods
+
+    private void MockApiResponse(string response)
+    {
+        _mockApiHelper
+            .Setup(x => x.CallToAPI(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                "GET",
+                It.IsAny<string>()))
+            .Returns(response);
+    }
+
+    private string SuccessResponse()
+    {
+        return JsonConvert.SerializeObject(new Dictionary<string, object>
+        {
+            ["id"] = "550e8400-e29b-41d4-a716-446655440000",
+            ["title"] = "Patient Intake Form",
+            ["description"] = "Please complete before your appointment.",
+            ["form_html"] = "<form>...</form>",
+            ["form_json"] = new { },
+            ["form_css"] = "form { font-family: sans-serif; }",
+            ["active"] = true,
+            ["customer_id"] = 123,
+            ["signable"] = false,
+            ["submission_count"] = 42,
+            ["version"] = 1,
+            ["deleted"] = false,
+            ["archived"] = false,
+            ["created_at"] = "2024-01-15T10:30:00Z",
+            ["updated_at"] = "2024-06-01T08:00:00Z"
+        });
+    }
+
+    private string NotFoundResponse()
+    {
+        return JsonConvert.SerializeObject(new Dictionary<string, object>
+        {
+            ["error"] = "Form not found"
+        });
+    }
+}

--- a/Paubox_Csharp/UnitTestProject/SubmitFormTest.cs
+++ b/Paubox_Csharp/UnitTestProject/SubmitFormTest.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Moq;
+using Paubox;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+[TestFixture]
+public class SubmitFormTest
+{
+    private Mock<IAPIHelper> _mockApiHelper;
+    private FormsLibrary _formsLibrary;
+
+    private const string FormId = "550e8400-e29b-41d4-a716-446655440000";
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockApiHelper = new Mock<IAPIHelper>();
+        _formsLibrary = new FormsLibrary(_mockApiHelper.Object);
+    }
+
+    [Test]
+    public void TestSubmitFormHappyCaseNoException()
+    {
+        MockApiResponse("");
+
+        Assert.DoesNotThrow(() => _formsLibrary.SubmitForm(FormId, new Dictionary<string, object>
+        {
+            ["first_name"] = "Jane",
+            ["last_name"] = "Smith",
+            ["email"] = "jane@example.com"
+        }));
+    }
+
+    [Test]
+    public void TestSubmitFormPayloadVerification()
+    {
+        string capturedBody = null;
+        _mockApiHelper
+            .Setup(x => x.CallToAPI(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                "POST",
+                It.IsAny<string>()))
+            .Callback<string, string, string, string, string>(
+                (baseUrl, uri, auth, verb, body) => { capturedBody = body; })
+            .Returns("");
+
+        _formsLibrary.SubmitForm(FormId, new Dictionary<string, object>
+        {
+            ["first_name"] = "Jane",
+            ["email"] = "jane@example.com"
+        });
+
+        Assert.IsNotNull(capturedBody);
+        var json = JObject.Parse(capturedBody);
+        Assert.IsNotNull(json["form_data"]);
+        Assert.AreEqual("Jane", json["form_data"]["first_name"].ToString());
+        Assert.AreEqual("jane@example.com", json["form_data"]["email"].ToString());
+        Assert.IsNull(json["attachments"]);
+    }
+
+    [Test]
+    public void TestSubmitFormWithAttachments()
+    {
+        string capturedBody = null;
+        _mockApiHelper
+            .Setup(x => x.CallToAPI(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                "POST",
+                It.IsAny<string>()))
+            .Callback<string, string, string, string, string>(
+                (baseUrl, uri, auth, verb, body) => { capturedBody = body; })
+            .Returns("");
+
+        var attachments = new[]
+        {
+            new FormAttachment { Name = "consent.pdf", Content = "JVBERi0xLjQ..." }
+        };
+
+        _formsLibrary.SubmitForm(FormId, new Dictionary<string, object>
+        {
+            ["first_name"] = "Jane"
+        }, attachments);
+
+        Assert.IsNotNull(capturedBody);
+        var json = JObject.Parse(capturedBody);
+        Assert.IsNotNull(json["attachments"]);
+        Assert.AreEqual(1, json["attachments"].ToObject<JArray>().Count);
+        Assert.AreEqual("consent.pdf", json["attachments"][0]["name"].ToString());
+        Assert.AreEqual("JVBERi0xLjQ...", json["attachments"][0]["content"].ToString());
+    }
+
+    [Test]
+    public void TestSubmitFormCallsCorrectUrl()
+    {
+        string capturedBaseUrl = null;
+        string capturedRequestUri = null;
+
+        _mockApiHelper
+            .Setup(x => x.CallToAPI(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()))
+            .Callback<string, string, string, string, string>(
+                (baseUrl, uri, auth, verb, body) =>
+                {
+                    capturedBaseUrl = baseUrl;
+                    capturedRequestUri = uri;
+                })
+            .Returns("");
+
+        _formsLibrary.SubmitForm(FormId, new Dictionary<string, object> { ["key"] = "value" });
+
+        Assert.AreEqual("https://next.paubox.com/", capturedBaseUrl);
+        Assert.AreEqual($"api/forms/{FormId}/submissions", capturedRequestUri);
+    }
+
+    [Test]
+    public void TestSubmitFormNullFormDataThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => _formsLibrary.SubmitForm(FormId, null));
+    }
+
+    [Test]
+    public void TestSubmitFormNullFormIdThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => _formsLibrary.SubmitForm(null,
+            new Dictionary<string, object> { ["key"] = "value" }));
+    }
+
+    [Test]
+    public void TestSubmitFormEmptyFormIdThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => _formsLibrary.SubmitForm("",
+            new Dictionary<string, object> { ["key"] = "value" }));
+    }
+
+    [Test]
+    public void TestSubmitFormErrorResponseThrowsSystemException()
+    {
+        MockApiResponse("{\"error\": \"Missing required form_data field\"}");
+
+        var exception = Assert.Throws<SystemException>(() => _formsLibrary.SubmitForm(FormId,
+            new Dictionary<string, object> { ["key"] = "value" }));
+
+        Assert.IsNotNull(exception.Message);
+        StringAssert.Contains("Missing required form_data field", exception.Message);
+    }
+
+    [Test]
+    public void TestSubmitFormPassesNoAuthorizationHeader()
+    {
+        string capturedAuth = "sentinel";
+
+        _mockApiHelper
+            .Setup(x => x.CallToAPI(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()))
+            .Callback<string, string, string, string, string>(
+                (baseUrl, uri, auth, verb, body) => { capturedAuth = auth; })
+            .Returns("");
+
+        _formsLibrary.SubmitForm(FormId, new Dictionary<string, object> { ["key"] = "value" });
+
+        Assert.IsNull(capturedAuth);
+    }
+
+    // ------------------------------------------------------------
+    // Helper methods
+
+    private void MockApiResponse(string response)
+    {
+        _mockApiHelper
+            .Setup(x => x.CallToAPI(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                "POST",
+                It.IsAny<string>()))
+            .Returns(response);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 # Paubox C# SDK <!-- omit in toc -->
 
-This is the official C# wrapper/SDK for the Paubox Email API.
+This is the official C# wrapper/SDK for the Paubox Email API and Paubox Forms.
 
 The Paubox Email API allows your application to send secure, HIPAA compliant email via Paubox and track deliveries and
 opens.
 
-The API wrapper allows you to construct and send messages.
+The Paubox Forms API allows your application to retrieve form definitions and submit form responses.
+
+The API wrapper allows you to construct and send messages, and interact with Paubox Forms.
 
 - [Installation](#installation)
   - [Getting Paubox API Credentials](#getting-paubox-api-credentials)
@@ -33,6 +35,11 @@ The API wrapper allows you to construct and send messages.
     - [Get Dynamic Template](#get-dynamic-template)
     - [List Dynamic Templates](#list-dynamic-templates)
     - [Send a Dynamically Templated Message](#send-a-dynamically-templated-message)
+- [Paubox Forms](#paubox-forms)
+  - [Initializing the FormsLibrary](#initializing-the-formslibrary)
+  - [Get Form](#get-form)
+  - [Submit Form](#submit-form)
+    - [Submitting with file attachments](#submitting-with-file-attachments)
 - [Contributing](#contributing)
 - [License](#license)
 - [Copyright](#copyright)
@@ -468,6 +475,97 @@ Then, call the `EmailLibrary.SendTemplatedMessage` method to send the message:
 
 ```csharp
 SendTemplatedMessageResponse response = paubox.SendTemplatedMessage(message);
+```
+
+## Paubox Forms
+
+The Paubox Forms integration provides two public endpoints for retrieving form definitions and
+submitting responses. **No API key is required** — these endpoints are intended for use by form
+respondents.
+
+Please also see the [API Documentation](https://docs.paubox.com/forms/get-form).
+
+### Initializing the FormsLibrary
+
+`FormsLibrary` requires no credentials:
+
+```csharp
+var forms = new FormsLibrary();
+```
+
+### Get Form
+
+Retrieves the full definition (HTML, JSON schema, CSS) for a given form UUID:
+
+```csharp
+string formId = "550e8400-e29b-41d4-a716-446655440000";
+Form form = forms.GetForm(formId);
+
+Console.WriteLine(form.Title);
+Console.WriteLine(form.FormHtml);
+Console.WriteLine(form.SubmissionCount);
+```
+
+The returned `Form` object includes:
+
+| Property | Type | Description |
+|---|---|---|
+| `Id` | `string` | Form UUID |
+| `Title` | `string` | Form display title |
+| `Description` | `string` | Optional description |
+| `FormHtml` | `string` | Rendered form HTML |
+| `FormJson` | `object` | JSON schema of form fields |
+| `FormCss` | `string` | Associated CSS |
+| `Active` | `bool` | Whether the form accepts submissions |
+| `Signable` | `bool` | Whether the form supports e-signatures |
+| `SubmissionCount` | `int` | Total submissions received |
+| `CreatedAt` | `DateTime` | Creation timestamp |
+| `UpdatedAt` | `DateTime` | Last update timestamp |
+
+### Submit Form
+
+Submits a respondent's answers. The keys in `formData` should match the field names defined in
+the form's schema (`FormJson`):
+
+```csharp
+string formId = "550e8400-e29b-41d4-a716-446655440000";
+
+forms.SubmitForm(formId, new Dictionary<string, object>
+{
+    { "first_name", "Jane" },
+    { "last_name", "Smith" },
+    { "email", "jane@example.com" }
+});
+```
+
+#### Submitting with file attachments
+
+File attachments are passed as `FormAttachment` objects with a filename and base64-encoded content.
+The maximum total request size is **250 MB**.
+
+```csharp
+string formId = "550e8400-e29b-41d4-a716-446655440000";
+
+// Read and base64-encode the file
+byte[] fileBytes = File.ReadAllBytes("path/to/consent.pdf");
+string base64Content = Convert.ToBase64String(fileBytes);
+
+forms.SubmitForm(
+    formId,
+    formData: new Dictionary<string, object>
+    {
+        { "first_name", "Jane" },
+        { "signature", "{signature_field}" }
+    },
+    attachments: new FormAttachment[]
+    {
+        new FormAttachment
+        {
+            Name = "consent.pdf",
+            Content = base64Content
+        }
+    }
+);
 ```
 
 ## Contributing

--- a/api.md
+++ b/api.md
@@ -1,0 +1,232 @@
+# Paubox C# SDK — API Reference
+
+## Table of Contents
+
+- [Email API](#email-api)
+  - [Authentication](#authentication)
+  - [EmailLibrary Methods](#emaillibrary-methods)
+- [Forms API](#forms-api)
+  - [FormsLibrary Methods](#formslibrary-methods)
+- [Error Handling](#error-handling)
+
+---
+
+## Email API
+
+**Base URL:** `https://api.paubox.net/v1/{apiUser}/`
+
+### Authentication
+
+All Email API requests require an `Authorization` header:
+
+```
+Authorization: Token token={apiKey}
+```
+
+Pass your `apiKey` and `apiUser` (your Paubox username/domain) when constructing `EmailLibrary`.
+
+### EmailLibrary Methods
+
+#### `SendMessage(Message message) → SendMessageResponse`
+
+Sends a single secure email.
+
+**Request body fields (via `Message`):**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `Recipients` | `string[]` | Yes | To addresses |
+| `Cc` | `string[]` | No | CC addresses |
+| `Bcc` | `string[]` | No | BCC addresses |
+| `Header.From` | `string` | Yes | Sender address |
+| `Header.Subject` | `string` | Yes | Email subject |
+| `Header.ReplyTo` | `string` | No | Reply-to address |
+| `Header.CustomHeaders` | `Dictionary<string,string>` | No | Additional headers |
+| `Content.PlainText` | `string` | No | Plain text body |
+| `Content.HtmlText` | `string` | No | HTML body (base64-encoded on the wire) |
+| `Attachments` | `List<Attachment>` | No | File attachments |
+| `AllowNonTLS` | `bool` | No | Allow unencrypted delivery (default: false) |
+| `ForceSecureNotification` | `string` | No | Force secure notification delivery |
+
+**Response:** `SendMessageResponse`
+
+| Field | Type | Description |
+|---|---|---|
+| `SourceTrackingId` | `string` | ID for tracking via `GetEmailDisposition` |
+| `Data` | `string` | Raw API data payload |
+| `CustomHeaders` | `Dictionary<string,string>` | Echoed custom headers |
+| `Errors` | `List<Error>` | Non-null on failure |
+
+---
+
+#### `SendBulkMessages(Message[] messages) → SendBulkMessagesResponse`
+
+Sends up to 50 messages in a single request. Recommended batch size: ≤ 50.
+
+**Response:** `SendBulkMessagesResponse`
+
+| Field | Type | Description |
+|---|---|---|
+| `Messages` | `List<BulkMessageResponse>` | Per-message results |
+
+Each `BulkMessageResponse` has the same fields as `SendMessageResponse`.
+
+---
+
+#### `SendTemplatedMessage(TemplatedMessage message) → SendMessageResponse`
+
+Sends a message rendered from a stored dynamic template.
+
+**Additional fields (via `TemplatedMessage`):**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `TemplateName` | `string` | Yes | Name of the dynamic template |
+| `TemplateValues` | `Dictionary<string,object>` | No | Variables injected into the template |
+
+---
+
+#### `GetEmailDisposition(string sourceTrackingId) → GetEmailDispositionResponse`
+
+Returns delivery and open status for a previously sent message.
+
+**Response:** `GetEmailDispositionResponse`
+
+| Field | Type | Description |
+|---|---|---|
+| `SourceTrackingId` | `string` | Echoed tracking ID |
+| `Data.Message.Id` | `string` | Message ID |
+| `Data.Message.Message_Deliveries` | `List<MessageDeliveries>` | Per-recipient status |
+| `Errors` | `List<Error>` | Non-null on failure |
+
+Each `MessageDeliveries` entry:
+
+| Field | Type | Description |
+|---|---|---|
+| `Recipient` | `string` | Recipient address |
+| `Status.DeliveryStatus` | `string` | e.g. `"delivered"` |
+| `Status.DeliveryTime` | `DateTime?` | When delivered |
+| `Status.OpenedStatus` | `string` | `"opened"` or `"unopened"` |
+| `Status.OpenedTime` | `DateTime?` | When first opened |
+
+---
+
+#### Dynamic Template Methods
+
+| Method | Signature | Description |
+|---|---|---|
+| `CreateDynamicTemplate` | `(string name, string templatePath) → DynamicTemplateResponse` | Upload a new Handlebars template |
+| `UpdateDynamicTemplate` | `(int id, string name, string templatePath) → DynamicTemplateResponse` | Replace or rename a template |
+| `DeleteDynamicTemplate` | `(int id) → DeleteDynamicTemplateResponse` | Remove a template |
+| `GetDynamicTemplate` | `(int id) → GetDynamicTemplateResponse` | Fetch a single template |
+| `ListDynamicTemplates` | `() → List<DynamicTemplateSummary>` | List all templates |
+
+---
+
+## Forms API
+
+**Base URL:** `https://next.paubox.com/`
+
+**Authentication:** None — these are public endpoints intended for form embed usage.
+
+### FormsLibrary Methods
+
+#### `GetForm(string formId) → Form`
+
+Retrieves the full definition of a form (HTML, JSON schema, CSS) by its UUID.
+
+**Path:** `GET /public/form_data/{form_id}`
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `formId` | `string` (UUID) | Yes | The form's unique identifier |
+
+**Response:** `Form`
+
+| Field | Type | Description |
+|---|---|---|
+| `Id` | `string` | Form UUID |
+| `Title` | `string` | Form display title |
+| `Description` | `string` | Optional description |
+| `FormHtml` | `string` | Rendered form HTML |
+| `FormJson` | `object` | JSON schema of form fields |
+| `FormCss` | `string` | Associated CSS |
+| `VanityUrl` | `string` | Custom URL slug |
+| `Version` | `int` | Schema version |
+| `Active` | `bool` | Whether the form accepts submissions |
+| `CustomerId` | `int` | Owning customer ID |
+| `Signable` | `bool` | Whether the form supports e-signatures |
+| `SignatureConfirmationLabel` | `string` | Label shown on signature confirmation |
+| `SubmissionCount` | `int` | Total submissions received |
+| `Type` | `string` | Form type |
+| `Deleted` | `bool` | Soft-delete flag |
+| `Archived` | `bool` | Archive flag |
+| `CreatedAt` | `DateTime` | Creation timestamp |
+| `UpdatedAt` | `DateTime` | Last update timestamp |
+
+**Errors:** Throws `SystemException` if the form is not found or the response is invalid.
+
+---
+
+#### `SubmitForm(string formId, Dictionary<string, object> formData, FormAttachment[] attachments = null) → void`
+
+Submits a respondent's answers for a form. On success, the service stores the submission,
+increments the form's submission count, and emails recipients if configured.
+
+Maximum request size: **250 MB** (to support file attachments).
+
+**Path:** `POST /api/forms/{form_id}/submissions`
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `formId` | `string` (UUID) | Yes | The form's unique identifier |
+| `formData` | `Dictionary<string, object>` | Yes | Key-value pairs matching the form's field schema |
+| `attachments` | `FormAttachment[]` | No | File attachments |
+
+**`FormAttachment` fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `Name` | `string` | Filename (e.g. `"consent.pdf"`) |
+| `Content` | `string` | Base64-encoded file bytes |
+
+**Errors:**
+- Throws `ArgumentNullException` if `formData` is null
+- Throws `ArgumentException` if `formId` is null or empty
+- Throws `SystemException` if the API returns an error response (400 form not found, 404 invalid form data, etc.)
+
+---
+
+## Error Handling
+
+Both libraries throw `SystemException` when the API returns an error, with the raw API response
+string as the exception message. Parse the message as JSON to extract structured error details.
+
+Example error response shape from the Email API:
+
+```json
+{
+  "errors": [
+    {
+      "code": 404,
+      "title": "Message was not found",
+      "details": "Message with this tracking id was not found"
+    }
+  ]
+}
+```
+
+The `Error` class maps these fields:
+
+```csharp
+public class Error
+{
+    public int Code { get; set; }
+    public string Title { get; set; }
+    public string Details { get; set; }
+}
+```


### PR DESCRIPTION
Introduces FormsLibrary and IFormsLibrary to wrap the two public Paubox
Forms endpoints (GET /public/form_data/{id} and POST /api/forms/{id}/submissions).
No authentication is required for these endpoints. Adds full NUnit test
coverage for both methods, and creates api.md and CLAUDE.md reference
documents alongside README updates.

https://claude.ai/code/session_019xkPDW9BXd2zWdCwYdBjPk