### PR TITLE
Add Paubox Forms API support (FormsLibrary)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This is the official Paubox C# SDK. It wraps two Paubox APIs:
 | Library | Class | Base URL | Auth |
 |---|---|---|---|
 | Email API | `EmailLibrary` | `https://api.paubox.net/v1/{apiUser}/` | `Token token={apiKey}` header |
-| Forms API | `FormsLibrary` | `https://next.paubox.com/` | None (public endpoints) |
+| Forms API | `FormsLibrary` | `https://apx.paubox.com/forms/` | None (public endpoints) |
 
 ## Repository Structure
 

--- a/Paubox_Csharp/EmailLib/FormsLibrary.cs
+++ b/Paubox_Csharp/EmailLib/FormsLibrary.cs
@@ -6,7 +6,7 @@ namespace Paubox
 {
     public class FormsLibrary : IFormsLibrary
     {
-        private const string FormsBaseUrl = "https://next.paubox.com/";
+        private const string FormsBaseUrl = "https://apx.paubox.com/forms/";
         private readonly IAPIHelper _apiHelper;
 
         public FormsLibrary() : this(new APIHelper())

--- a/Paubox_Csharp/UnitTestProject/GetFormTest.cs
+++ b/Paubox_Csharp/UnitTestProject/GetFormTest.cs
@@ -93,7 +93,7 @@ public class GetFormTest
 
         _formsLibrary.GetForm("550e8400-e29b-41d4-a716-446655440000");
 
-        Assert.AreEqual("https://next.paubox.com/", capturedBaseUrl);
+        Assert.AreEqual("https://apx.paubox.com/forms/", capturedBaseUrl);
         Assert.AreEqual("public/form_data/550e8400-e29b-41d4-a716-446655440000", capturedRequestUri);
     }
 

--- a/Paubox_Csharp/UnitTestProject/SubmitFormTest.cs
+++ b/Paubox_Csharp/UnitTestProject/SubmitFormTest.cs
@@ -119,7 +119,7 @@ public class SubmitFormTest
 
         _formsLibrary.SubmitForm(FormId, new Dictionary<string, object> { ["key"] = "value" });
 
-        Assert.AreEqual("https://next.paubox.com/", capturedBaseUrl);
+        Assert.AreEqual("https://apx.paubox.com/forms/", capturedBaseUrl);
         Assert.AreEqual($"api/forms/{FormId}/submissions", capturedRequestUri);
     }
 

--- a/api.md
+++ b/api.md
@@ -125,7 +125,7 @@ Each `MessageDeliveries` entry:
 
 ## Forms API
 
-**Base URL:** `https://next.paubox.com/`
+**Base URL:** `https://apx.paubox.com/forms/`
 
 **Authentication:** None — these are public endpoints intended for form embed usage.
 


### PR DESCRIPTION
## Summary

- Adds `FormsLibrary` and `IFormsLibrary` to wrap the two public Paubox Forms endpoints (no API key required)
- `GetForm(formId)` — `GET https://apx.paubox.com/forms/public/form_data/{id}` — returns a `Form` object with the full form definition (HTML, JSON schema, CSS, metadata)
- `SubmitForm(formId, formData, attachments?)` — `POST https://apx.paubox.com/forms/api/forms/{id}/submissions` — submits respondent answers, supports optional base64 file attachments up to 250 MB
- Adds `FormsClasses.cs` with `Form` and `FormAttachment` model classes
- Full NUnit test coverage in `GetFormTest.cs` and `SubmitFormTest.cs` (happy path, error cases, payload shape, URL verification, no-auth assertion)
- Creates `api.md` (API reference for both Email and Forms libraries) and `CLAUDE.md` (developer context for AI-assisted work)
- Updates `README.md` with a Paubox Forms section including usage examples

## Test plan

- [ ] `dotnet build Paubox_Csharp/Paubox_Csharp.sln` passes with no errors
- [ ] `dotnet test Paubox_Csharp/UnitTestProject/UnitTestProject.csproj` — all tests pass including the 14 new Forms tests
- [ ] Instantiate `new FormsLibrary()` and call `GetForm` against a real form UUID to verify the live endpoint responds correctly
- [ ] Call `SubmitForm` with a test form to verify a 201 response is handled without exception

https://claude.ai/code/session_019xkPDW9BXd2zWdCwYdBjPk

---
_Generated by [Claude Code](https://claude.ai/code/session_019xkPDW9BXd2zWdCwYdBjPk)_